### PR TITLE
Switch docker reflection from grpcurl to yagrc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,16 +3,14 @@ LABEL maintainer="neurocis <neurocis@neurocis.me>"
 
 RUN true && \
 \
-# Install GRPCurl
-wget https://github.com/fullstorydev/grpcurl/releases/download/v1.8.0/grpcurl_1.8.0_linux_x86_64.tar.gz && \
-tar -xvf grpcurl_1.8.0_linux_x86_64.tar.gz grpcurl && \
-chown root:root grpcurl && \
-chmod 755 grpcurl && \
-mv grpcurl /usr/bin/. && \
-rm grpcurl_1.8.0_linux_x86_64.tar.gz && \
-\
 # Install python prerequisites
-pip3 install grpcio grpcio-tools paho-mqtt influxdb
+pip3 install \
+    grpcio==1.36.1 \
+    paho-mqtt==1.5.1 \
+    influxdb==5.3.1 python-dateutil==2.8.1 pytz==2021.1 requests==2.25.1 \
+        certifi==2020.12.5 chardet==4.0.0 idna==2.10 urllib3==1.26.4 \
+        six==1.15.0 msgpack==1.0.2 \
+    yagrc==1.1.0 grpcio-reflection==1.36.1 protobuf==3.15.6
 
 ADD . /app
 WORKDIR /app

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,13 +2,4 @@
 
 printenv >> /etc/environment
 ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
-grpcurl -plaintext -protoset-out dish.protoset 192.168.100.1:9200 describe SpaceX.API.Device.Device > /dev/null
-python3 -m grpc_tools.protoc --descriptor_set_in=dish.protoset --python_out=. --grpc_python_out=. spacex/api/device/device.proto
-python3 -m grpc_tools.protoc --descriptor_set_in=dish.protoset --python_out=. --grpc_python_out=. spacex/api/common/status/status.proto
-python3 -m grpc_tools.protoc --descriptor_set_in=dish.protoset --python_out=. --grpc_python_out=. spacex/api/device/command.proto
-python3 -m grpc_tools.protoc --descriptor_set_in=dish.protoset --python_out=. --grpc_python_out=. spacex/api/device/common.proto
-python3 -m grpc_tools.protoc --descriptor_set_in=dish.protoset --python_out=. --grpc_python_out=. spacex/api/device/dish.proto
-python3 -m grpc_tools.protoc --descriptor_set_in=dish.protoset --python_out=. --grpc_python_out=. spacex/api/device/wifi.proto
-python3 -m grpc_tools.protoc --descriptor_set_in=dish.protoset --python_out=. --grpc_python_out=. spacex/api/device/wifi_config.proto
-python3 -m grpc_tools.protoc --descriptor_set_in=dish.protoset --python_out=. --grpc_python_out=. spacex/api/device/transceiver.proto
 exec /usr/local/bin/python3 $@


### PR DESCRIPTION
Remove grpcurl and grpcio-tools from container configuration and add yagrc, so that the direct reflection support in the Python scripts can be used. Also, pin all Python packages, including package dependencies, to specific version numbers, since that was already the case by happenstance due to the way Docker caches its build images and an undesirable version of the protobuf package was being cached.

Addresses #23, which was directly about this change.
Expected to also address #22, as a result of pinning the protobuf package version.
Should also prevent a recurrence of #18, since yagrc will automatically get any new dependant protocol files via reflection.