### PR TITLE
Added support for GPS location and new alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,6 @@ return data in a format Prometheus can scrape.
 
 All these scripts support processing status data and/or history data in various modes. The status data is mostly what appears related to the dish in the Debug Data section of the Starlink app, whereas most of the data displayed in the Statistics page of the Starlink app comes from the history data. Specific status or history data groups can be selected by including their mode names on the command line. Run the scripts with `-h` command line option to get a list of available modes. See the documentation at the top of `starlink_grpc.py` for detail on what each of the fields means within each mode group.
 
-`dish_grpc_prometheus.py` only allows the modes `status`, `usage`, and `alert_detail`.
-
 For example, data from all the currently available status groups can be output by doing:
 ```shell script
 python3 dish_grpc_text.py status obstruction_detail alert_detail

--- a/dish_grpc_prometheus.py
+++ b/dish_grpc_prometheus.py
@@ -41,6 +41,9 @@ class MetricInfo:
 
 METRICS_INFO = {
     "status_uptime": MetricInfo(unit="seconds", kind="counter"),
+    "status_longitude": MetricInfo(),
+    "status_latitude": MetricInfo(),
+    "status_altitude": MetricInfo(),
     "status_seconds_to_first_nonempty_slot": MetricInfo(),
     "status_pop_ping_drop_rate": MetricInfo(),
     "status_downlink_throughput_bps": MetricInfo(),
@@ -65,6 +68,13 @@ METRICS_INFO = {
     "status_alert_install_pending": MetricInfo(),
     "status_alert_is_heating": MetricInfo(),
     "status_alert_power_supply_thermal_throttle": MetricInfo(),
+    "status_alert_slow_ethernet_speeds_100": MetricInfo(),
+    "status_alert_is_power_save_idle": MetricInfo(),
+    "status_alert_moving_while_not_mobile": MetricInfo(),
+    "status_alert_moving_too_fast_for_policy": MetricInfo(),
+    "status_alert_dbf_telem_stale": MetricInfo(),
+    "status_alert_low_motor_current": MetricInfo(),
+    "status_alert_lower_signal_than_predicted": MetricInfo(),
     "ping_stats_samples": MetricInfo(kind="counter"),
     "ping_stats_end_counter": MetricInfo(kind="counter"),
     "usage_download_usage": MetricInfo(unit="bytes", kind="counter"),
@@ -141,7 +151,7 @@ def parse_args():
     group.add_argument("--address", default="0.0.0.0", help="IP address to listen on")
     group.add_argument("--port", default=8080, type=int, help="Port to listen on")
 
-    return dish_common.run_arg_parser(parser, modes=["status", "alert_detail", "usage"])
+    return dish_common.run_arg_parser(parser, modes=["status", "alert_detail", "usage", "location"])
 
 
 def prometheus_export(opts, gstate):


### PR DESCRIPTION
The dish_common already has the ability to provide the location information, i just allowed the dish_grpc_prometheus.py script to print those values. I have also enabled some alerts for monitoring purposes.
Might be useful to someone else.