### PR TITLE
Add support for power consumption data

### DIFF
--- a/dish_common.py
+++ b/dish_common.py
@@ -26,7 +26,7 @@ BRACKETS_RE = re.compile(r"([^[]*)(\[((\d+),|)(\d*)\]|)$")
 LOOP_TIME_DEFAULT = 0
 STATUS_MODES: List[str] = ["status", "obstruction_detail", "alert_detail", "location"]
 HISTORY_STATS_MODES: List[str] = [
-    "ping_drop", "ping_run_length", "ping_latency", "ping_loaded_latency", "usage"
+    "ping_drop", "ping_run_length", "ping_latency", "ping_loaded_latency", "usage", "power"
 ]
 UNGROUPED_MODES: List[str] = []
 
@@ -370,7 +370,7 @@ def get_history_stats(opts, gstate, add_item, add_sequence, flush_history):
                                          start=start,
                                          verbose=opts.verbose,
                                          history=gstate.accum_history)
-    general, ping, runlen, latency, loaded, usage = groups[0:6]
+    general, ping, runlen, latency, loaded, usage, power = groups[0:7]
     add_data = add_data_numeric if opts.numeric else add_data_normal
     add_data(general, "ping_stats", add_item, add_sequence)
     if "ping_drop" in opts.mode:
@@ -383,6 +383,8 @@ def get_history_stats(opts, gstate, add_item, add_sequence, flush_history):
         add_data(loaded, "ping_stats", add_item, add_sequence)
     if "usage" in opts.mode:
         add_data(usage, "usage", add_item, add_sequence)
+    if "power" in opts.mode:
+        add_data(power, "power", add_item, add_sequence)
     if not opts.no_counter:
         gstate.counter_stats = general["end_counter"]
 

--- a/dish_grpc_influx.py
+++ b/dish_grpc_influx.py
@@ -12,6 +12,7 @@ measurement / series names:
 : spacex.starlink.user_terminal.history : Bulk history data
 : spacex.starlink.user_terminal.ping_stats : Ping history statistics
 : spacex.starlink.user_terminal.usage : Usage history statistics
+: spacex.starlink.user_terminal.power : Power history statistics
 
 NOTE: The Starlink user terminal does not include time values with its
 history or status data, so this script uses current system time to compute
@@ -223,7 +224,7 @@ def sync_timebase(opts, gstate):
 
 
 def loop_body(opts, gstate, shutdown=False):
-    fields = {"status": {}, "ping_stats": {}, "usage": {}}
+    fields = {"status": {}, "ping_stats": {}, "usage": {}, "power": {}}
 
     def cb_add_item(key, val, category):
         fields[category][key] = val

--- a/dish_grpc_influx2.py
+++ b/dish_grpc_influx2.py
@@ -12,6 +12,7 @@ measurement / series names:
 : spacex.starlink.user_terminal.history : Bulk history data
 : spacex.starlink.user_terminal.ping_stats : Ping history statistics
 : spacex.starlink.user_terminal.usage : Usage history statistics
+: spacex.starlink.user_terminal.power : Power history statistics
 
 NOTE: The Starlink user terminal does not include time values with its
 history or status data, so this script uses current system time to compute
@@ -220,7 +221,7 @@ def sync_timebase(opts, gstate):
 
 
 def loop_body(opts, gstate, shutdown=False):
-    fields = {"status": {}, "ping_stats": {}, "usage": {}}
+    fields = {"status": {}, "ping_stats": {}, "usage": {}, "power": {}}
 
     def cb_add_item(key, val, category):
         fields[category][key] = val

--- a/dish_grpc_mqtt.py
+++ b/dish_grpc_mqtt.py
@@ -10,6 +10,7 @@ Data will be published to the following topic names:
 : starlink/dish_status/*id_value*/*field_name* : Current status data
 : starlink/dish_ping_stats/*id_value*/*field_name* : Ping history statistics
 : starlink/dish_usage/*id_value*/*field_name* : Usage history statistics
+: starlink/dish_power/*id_value*/*field_name* : Power history statistics
 
 Where *id_value* is the *id* value from the dish status information.
 

--- a/dish_grpc_sqlite.py
+++ b/dish_grpc_sqlite.py
@@ -10,7 +10,8 @@ Requested data will be written into the following tables:
 : status : Current status data
 : history : Bulk history data
 : ping_stats : Ping history statistics
-: usage : Usage history statistics
+: usage : Bandwidth usage history statistics
+: power : Power consumption history statistics
 
 Array data is currently written to the database as text strings of comma-
 separated values, which may not be the best method for some use cases. If you
@@ -46,7 +47,7 @@ import time
 import dish_common
 import starlink_grpc
 
-SCHEMA_VERSION = 4
+SCHEMA_VERSION = 5
 
 
 class Terminated(Exception):
@@ -100,7 +101,7 @@ def query_counter(opts, gstate, column, table):
 
 
 def loop_body(opts, gstate, shutdown=False):
-    tables = {"status": {}, "ping_stats": {}, "usage": {}}
+    tables = {"status": {}, "ping_stats": {}, "usage": {}, "power": {}}
     hist_cols = ["time", "id"]
     hist_rows = []
 
@@ -218,6 +219,7 @@ def create_tables(conn, context, suffix):
     type_groups = starlink_grpc.history_stats_field_types()
     tables["ping_stats"] = zip(name_groups[0:5], type_groups[0:5])
     tables["usage"] = ((name_groups[5], type_groups[5]),)
+    tables["power"] = ((name_groups[6], type_groups[6]),)
 
     name_groups = starlink_grpc.history_bulk_field_names()
     type_groups = starlink_grpc.history_bulk_field_types()


### PR DESCRIPTION
Add power consumption data into both bulk history and history stats reporting. Note that this functionality is not supported on all user terminal (dish) hardware versions.

In the core module, for bulk history, this is added as a new field in the bulk history return dict. For history stats, this is a added as a newly added dict in the tuple returned from the history_stats.

In the command line tools, the existing bulk_history data mode will now return the power history as a new field, and the newly added power data mode will return a few statistics computed over the sample period.

This is for issue #94.