### PR TITLE
Add Tilt config control

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,33 +109,24 @@ python3 dish_control.py set_gps -h
 ```
 **NOTE**: This has no impact on whether or not the location data can be polled (see [above section](#enabling-access-to-location-data)). It only instructs the dish whether or not to use GPS for its own purposes. If this is not meaningful to you, then you should probably not mess with this setting. Note also that this setting is not preserved across dish reboot, at which point it will reset to the default of GPS enabled.
 
-It can also control the dish's tilt mode settings. You can get usage instructions for that by doing:
+It can also control the dish's tilt/level mode settings. You can get usage instructions for that by doing:
 ```shell script
 python3 dish_control.py set_tilt -h
 ```
-The tilt control allows you to:
-- Enable/disable flat mode: When enabled, keeps the dish parallel to the ground
-- Enable/disable automatic tilt: When enabled, allows the dish to automatically adjust its tilt angle for optimal signal
+The tilt/level control allows you to:
+- Force the dish to stay level (parallel to ground)
+- Allow normal automatic tilt adjustment (default behavior)
 
 For example:
 ```shell script
-# Show current tilt settings
+# Show current tilt/level settings
 python3 dish_control.py set_tilt
 
-# Enable flat mode
-python3 dish_control.py set_tilt --flat
+# Force dish to stay level
+python3 dish_control.py set_tilt --level
 
-# Disable flat mode
-python3 dish_control.py set_tilt --no-flat
-
-# Enable automatic tilt adjustment
-python3 dish_control.py set_tilt --automatic
-
-# Disable automatic tilt adjustment
-python3 dish_control.py set_tilt --no-automatic
-
-# Set both options at once
-python3 dish_control.py set_tilt --flat --no-automatic
+# Allow normal tilt adjustment
+python3 dish_control.py set_tilt --no-level
 ```
 
 Finally, all the commands supported by this script can be run periodically, either by using the `-t` option most of the other scripts support, or the `-c` option to use the cron-like scheduler described in the [next section](#firmware-update-checking-and-triggering).

--- a/README.md
+++ b/README.md
@@ -109,6 +109,35 @@ python3 dish_control.py set_gps -h
 ```
 **NOTE**: This has no impact on whether or not the location data can be polled (see [above section](#enabling-access-to-location-data)). It only instructs the dish whether or not to use GPS for its own purposes. If this is not meaningful to you, then you should probably not mess with this setting. Note also that this setting is not preserved across dish reboot, at which point it will reset to the default of GPS enabled.
 
+It can also control the dish's tilt mode settings. You can get usage instructions for that by doing:
+```shell script
+python3 dish_control.py set_tilt -h
+```
+The tilt control allows you to:
+- Enable/disable flat mode: When enabled, keeps the dish parallel to the ground
+- Enable/disable automatic tilt: When enabled, allows the dish to automatically adjust its tilt angle for optimal signal
+
+For example:
+```shell script
+# Show current tilt settings
+python3 dish_control.py set_tilt
+
+# Enable flat mode
+python3 dish_control.py set_tilt --flat
+
+# Disable flat mode
+python3 dish_control.py set_tilt --no-flat
+
+# Enable automatic tilt adjustment
+python3 dish_control.py set_tilt --automatic
+
+# Disable automatic tilt adjustment
+python3 dish_control.py set_tilt --no-automatic
+
+# Set both options at once
+python3 dish_control.py set_tilt --flat --no-automatic
+```
+
 Finally, all the commands supported by this script can be run periodically, either by using the `-t` option most of the other scripts support, or the `-c` option to use the cron-like scheduler described in the [next section](#firmware-update-checking-and-triggering).
 
 #### Firmware update checking and triggering


### PR DESCRIPTION
fixes #113 

## DRAFT - not working. I'll test and fix this in the summer when I activate my Starlink plan again. (Starlink is in my Van.)

## Testing progress

- python3 dish_control.py set_tilt works
- dish_control.py set_tilt --level and  --no-level give proto errors.


## Description
Added support for controlling and documenting dish tilt functionality through:

1. Enhanced `starlink_grpc.py`:
   - Added `get_tilt_config()` function to retrieve current tilt settings
   - Added `set_tilt_config()` function to configure tilt mode settings
   - Added comprehensive docstrings explaining tilt functionality and parameters

2. Updated `dish_control.py`:
   - Added `set_tilt` command with `--flat` and `--automatic` options
   - Added detailed help text and examples for tilt control
   - Implemented command-line parsing for tilt settings

3. Updated `README.md`:
   - Added tilt control documentation in "Reboot, stow, sleep, and GPS control" section
   - Added examples showing how to use tilt control commands
   - Clarified that tilt settings affect dish positioning
