### PR TITLE
update gRPC descriptor for latest Starlink firmware

### DIFF
--- a/dish_check_update.py
+++ b/dish_check_update.py
@@ -15,9 +15,9 @@ import grpc
 import loop_util
 import starlink_grpc
 
-# This is the enum value spacex.api.device.dish_pb2.SoftwareUpdateState.REBOOT_REQUIRED
+# This is the enum value spacex_api.device.dish_pb2.SoftwareUpdateState.REBOOT_REQUIRED
 REBOOT_REQUIRED = 6
-# This is the enum value spacex.api.device.dish_pb2.SoftwareUpdateState.DISABLED
+# This is the enum value spacex_api.device.dish_pb2.SoftwareUpdateState.DISABLED
 UPDATE_DISABLED = 7
 
 

--- a/dish_grpc_text.py
+++ b/dish_grpc_text.py
@@ -11,7 +11,7 @@ order in the output can change with the dish software. Instead of using
 the alert_detail mode, you can use the alerts bitmask in the status group.
 """
 
-from datetime import datetime
+import datetime
 import logging
 import os
 import signal
@@ -218,8 +218,8 @@ def loop_body(opts, gstate, print_file, shutdown=False):
     def cb_add_bulk(bulk, count, timestamp, counter):
         if opts.verbose:
             print("Time range (UTC):      {0} -> {1}".format(
-                datetime.utcfromtimestamp(timestamp).isoformat(),
-                datetime.utcfromtimestamp(timestamp + count).isoformat()),
+                datetime.datetime.fromtimestamp(timestamp, datetime.timezone.utc).isoformat(),
+                datetime.datetime.fromtimestamp(timestamp + count, datetime.timezone.utc).isoformat()),
                   file=print_file)
             for key, val in bulk.items():
                 print("{0:22} {1}".format(key + ":", ", ".join(xform(subval) for subval in val)),
@@ -229,7 +229,7 @@ def loop_body(opts, gstate, print_file, shutdown=False):
         else:
             for i in range(count):
                 timestamp += 1
-                fields = [datetime.utcfromtimestamp(timestamp).isoformat()]
+                fields = [datetime.datetime.fromtimestamp(timestamp, datetime.timezone.utc).isoformat()]
                 fields.extend([xform(val[i]) for val in bulk.values()])
                 print(",".join(fields), file=print_file)
 
@@ -248,7 +248,7 @@ def loop_body(opts, gstate, print_file, shutdown=False):
     else:
         if csv_data:
             timestamp = status_ts if status_ts is not None else hist_ts
-            csv_data.insert(0, datetime.utcfromtimestamp(timestamp).isoformat())
+            csv_data.insert(0, datetime.datetime.fromtimestamp(timestamp, datetime.timezone.utc).isoformat())
             print(",".join(csv_data), file=print_file)
 
     return rc

--- a/dish_grpc_text.py
+++ b/dish_grpc_text.py
@@ -218,8 +218,8 @@ def loop_body(opts, gstate, print_file, shutdown=False):
     def cb_add_bulk(bulk, count, timestamp, counter):
         if opts.verbose:
             print("Time range (UTC):      {0} -> {1}".format(
-                datetime.datetime.fromtimestamp(timestamp, datetime.timezone.utc).isoformat(),
-                datetime.datetime.fromtimestamp(timestamp + count, datetime.timezone.utc).isoformat()),
+                datetime.datetime.fromtimestamp(timestamp, datetime.timezone.utc).replace(tzinfo=None).isoformat(),
+                datetime.datetime.fromtimestamp(timestamp + count, datetime.timezone.utc).replace(tzinfo=None).isoformat()),
                   file=print_file)
             for key, val in bulk.items():
                 print("{0:22} {1}".format(key + ":", ", ".join(xform(subval) for subval in val)),
@@ -229,7 +229,7 @@ def loop_body(opts, gstate, print_file, shutdown=False):
         else:
             for i in range(count):
                 timestamp += 1
-                fields = [datetime.datetime.fromtimestamp(timestamp, datetime.timezone.utc).isoformat()]
+                fields = [datetime.datetime.fromtimestamp(timestamp, datetime.timezone.utc).replace(tzinfo=None).isoformat()]
                 fields.extend([xform(val[i]) for val in bulk.values()])
                 print(",".join(fields), file=print_file)
 
@@ -248,7 +248,7 @@ def loop_body(opts, gstate, print_file, shutdown=False):
     else:
         if csv_data:
             timestamp = status_ts if status_ts is not None else hist_ts
-            csv_data.insert(0, datetime.datetime.fromtimestamp(timestamp, datetime.timezone.utc).isoformat())
+            csv_data.insert(0, datetime.datetime.fromtimestamp(timestamp, datetime.timezone.utc).replace(tzinfo=None).isoformat())
             print(",".join(csv_data), file=print_file)
 
     return rc

--- a/dish_json_text.py
+++ b/dish_json_text.py
@@ -11,8 +11,7 @@ it will print the results in CSV format.
 """
 
 import argparse
-from datetime import datetime
-from datetime import timezone
+import datetime
 import logging
 import re
 import sys
@@ -120,11 +119,11 @@ def parse_args():
         except ValueError:
             try:
                 opts.history_time = int(
-                    datetime.strptime(opts.timestamp, "%Y-%m-%d_%H:%M:%S").timestamp())
+                    datetime.datetime.strptime(opts.timestamp, "%Y-%m-%d_%H:%M:%S").timestamp())
             except ValueError:
                 parser.error("Could not parse timestamp")
         if opts.verbose:
-            print("Using timestamp", datetime.fromtimestamp(opts.history_time, tz=timezone.utc))
+            print("Using timestamp", datetime.datetime.fromtimestamp(opts.history_time, tz=datetime.timezone.utc))
 
     return opts
 
@@ -207,7 +206,7 @@ def get_data(opts, add_item, add_sequence, add_bulk):
         new_counter = general["end_counter"]
         if opts.verbose:
             print("Establishing time base: {0} -> {1}".format(
-                new_counter, datetime.fromtimestamp(timestamp, tz=timezone.utc)))
+                new_counter, datetime.datetime.fromtimestamp(timestamp, tz=datetime.timezone.utc)))
         timestamp -= parsed_samples
 
         add_bulk(bulk, parsed_samples, timestamp, new_counter - parsed_samples)
@@ -220,7 +219,7 @@ def loop_body(opts):
         csv_data = []
     else:
         history_time = int(time.time()) if opts.history_time is None else opts.history_time
-        csv_data = [datetime.utcfromtimestamp(history_time).isoformat()]
+        csv_data = [datetime.datetime.fromtimestamp(history_time, datetime.timezone.utc).isoformat()]
 
     def cb_data_add_item(name, val):
         if opts.verbose:
@@ -242,14 +241,14 @@ def loop_body(opts):
     def cb_add_bulk(bulk, count, timestamp, counter):
         if opts.verbose:
             print("Time range (UTC):      {0} -> {1}".format(
-                datetime.utcfromtimestamp(timestamp).isoformat(),
-                datetime.utcfromtimestamp(timestamp + count).isoformat()))
+                datetime.datetime.fromtimestamp(timestamp, datetime.timezone.utc).isoformat(),
+                datetime.datetime.fromtimestamp(timestamp + count, datetime.timezone.utc).isoformat()))
             for key, val in bulk.items():
                 print("{0:22} {1}".format(key + ":", ", ".join(str(subval) for subval in val)))
         else:
             for i in range(count):
                 timestamp += 1
-                fields = [datetime.utcfromtimestamp(timestamp).isoformat()]
+                fields = [datetime.datetime.fromtimestamp(timestamp, datetime.timezone.utc).isoformat()]
                 fields.extend(["" if val[i] is None else str(val[i]) for val in bulk.values()])
                 print(",".join(fields))
 

--- a/dish_json_text.py
+++ b/dish_json_text.py
@@ -219,7 +219,7 @@ def loop_body(opts):
         csv_data = []
     else:
         history_time = int(time.time()) if opts.history_time is None else opts.history_time
-        csv_data = [datetime.datetime.fromtimestamp(history_time, datetime.timezone.utc).isoformat()]
+        csv_data = [datetime.datetime.fromtimestamp(history_time, datetime.timezone.utc).replace(tzinfo=None).isoformat()]
 
     def cb_data_add_item(name, val):
         if opts.verbose:
@@ -241,14 +241,14 @@ def loop_body(opts):
     def cb_add_bulk(bulk, count, timestamp, counter):
         if opts.verbose:
             print("Time range (UTC):      {0} -> {1}".format(
-                datetime.datetime.fromtimestamp(timestamp, datetime.timezone.utc).isoformat(),
-                datetime.datetime.fromtimestamp(timestamp + count, datetime.timezone.utc).isoformat()))
+                datetime.datetime.fromtimestamp(timestamp, datetime.timezone.utc).replace(tzinfo=None).isoformat(),
+                datetime.datetime.fromtimestamp(timestamp + count, datetime.timezone.utc).replace(tzinfo=None).isoformat()))
             for key, val in bulk.items():
                 print("{0:22} {1}".format(key + ":", ", ".join(str(subval) for subval in val)))
         else:
             for i in range(count):
                 timestamp += 1
-                fields = [datetime.datetime.fromtimestamp(timestamp, datetime.timezone.utc).isoformat()]
+                fields = [datetime.datetime.fromtimestamp(timestamp, datetime.timezone.utc).replace(tzinfo=None).isoformat()]
                 fields.extend(["" if val[i] is None else str(val[i]) for val in bulk.values()])
                 print(",".join(fields))
 

--- a/dump_dish_status.py
+++ b/dump_dish_status.py
@@ -6,8 +6,8 @@ import sys
 import grpc
 
 try:
-    from spacex.api.device import device_pb2
-    from spacex.api.device import device_pb2_grpc
+    from spacex_api.device import device_pb2
+    from spacex_api.device import device_pb2_grpc
 except ModuleNotFoundError:
     print("This script requires the generated gRPC protocol modules. See README file for details.",
           file=sys.stderr)

--- a/starlink_grpc.py
+++ b/starlink_grpc.py
@@ -406,14 +406,14 @@ import grpc
 
 try:
     from yagrc import importer
-    importer.add_lazy_packages(["spacex.api.device"])
+    importer.add_lazy_packages(["spacex_api.device"])
     imports_pending = True
 except (ImportError, AttributeError):
     imports_pending = False
 
-from spacex.api.device import device_pb2
-from spacex.api.device import device_pb2_grpc
-from spacex.api.device import dish_pb2
+from spacex_api.device import device_pb2
+from spacex_api.device import device_pb2_grpc
+from spacex_api.device import dish_pb2
 
 # Max wait time for gRPC request completion, in seconds. This is just to
 # prevent hang if the connection goes dead without closing.


### PR DESCRIPTION
The latest firmware changes the proto namespace from `spacex.api.device` to `spacex_api.device`. This fixes the issue where the error `no proto found` is thrown because of the change.

No backwards compatability has been added as I presume this change is rolling out globally over the coming days/weeks.

Also fixes the datetime depreciation messages.